### PR TITLE
(QA-2358) Add CLI Interface for Version

### DIFF
--- a/vmpooler_client/command_parser.py
+++ b/vmpooler_client/command_parser.py
@@ -84,18 +84,14 @@ class CommandParser(object):
     if cmd_name not in self._commands:
       command = self._sub_parsers.add_parser(cmd_name, description=desc)
 
-      # Add a subparser for sub-commands under a top-level command. (i.e. "list" for "vm")
       if func:
         self._commands[cmd_name] = command
+
+        # Set the function for a command that will have no sub-commands.
         self._commands[cmd_name].set_defaults(func=func)
-
-        # Tack on this bit of meta-data to indicate that sub-commands are NOT allowed.
-        self._commands[cmd_name]._allow_sub_cmd = False
       else:
+        # Add a subparser for sub-commands under a top-level command. (i.e. "list" for "vm")
         self._commands[cmd_name] = command.add_subparsers()
-
-        # Tack on this bit of meta-data to indicate that sub-commands are ALLOWED
-        self._commands[cmd_name]._allow_sub_cmd = True
     else:
       raise KeyError("The '{}' command has already been defined!".format(cmd_name))
 
@@ -150,7 +146,9 @@ class CommandParser(object):
 
     if parent not in self._commands:
       raise KeyError("The '{}' parent command has not been defined yet!".format(parent))
-    elif not self._commands[parent]._allow_sub_cmd:
+    elif isinstance(self._commands[parent], argparse.ArgumentParser):
+      # If the parent is of the class "_SubParsersAction" then that means it
+      # can accept sub-commands.
       raise RuntimeError("The '{}' parent command does not allow sub-commands!".format(parent))
     elif sub_cmd_key in self._sub_commands:
       raise KeyError("The '{}' sub-command has already been defined!".format(sub_cmd_key))

--- a/vmpooler_client/command_parser.py
+++ b/vmpooler_client/command_parser.py
@@ -1,5 +1,5 @@
 """
-.. module:: vmpooler_client.lib.command_parser
+.. module:: vmpooler_client.command_parser
    :synopsis: A class for configuring the command-line parser.
    :platform: Unix, Linux, Windows
    :license: BSD
@@ -65,27 +65,66 @@ class CommandParser(object):
     self._commands = {}
     self._sub_commands = {}
 
-  def add_command(self, cmd_name, desc):
+  def add_command(self, cmd_name, desc, func=None):
     """Create a top-level command.
 
     Args:
       cmd_name |str| = The name of the command.
       desc |str| = A description of the command.
+      func |func| = A function to use for commands that do not allow sub-commands.
+        If any value is supplied it is assumed that the command will never use sub-commands.
 
     Returns:
       None
 
     Raises:
-      |KeyError| Command name has already been defined.
+      |KeyError| = Command name has already been defined.
     """
 
     if cmd_name not in self._commands:
       command = self._sub_parsers.add_parser(cmd_name, description=desc)
 
       # Add a subparser for sub-commands under a top-level command. (i.e. "list" for "vm")
-      self._commands[cmd_name] = command.add_subparsers()
+      if func is None:
+        self._commands[cmd_name] = command.add_subparsers()
+
+        # Tack on this bit of meta-data to indicate that sub-commands are ALLOWED
+        self._commands[cmd_name]._allow_sub_cmd = True
+      else:
+        self._commands[cmd_name] = command
+        self._commands[cmd_name].set_defaults(func=func)
+
+        # Tack on this bit of meta-data to indicate that sub-commands are NOT allowed.
+        self._commands[cmd_name]._allow_sub_cmd = False
     else:
       raise KeyError("The '{}' command has already been defined!".format(cmd_name))
+
+  def add_command_arg(self, command, **kwargs):
+    """Add an argument to a command. This only works with commands that do not allow
+    sub-commands!
+
+    Args:
+      command |str| = The name of the top-level command.
+      **kwargs |{str:obj}| = An arbitrary number of keyword arguments to pass to the
+        "ArgumentParser.add_argument()" method. The "name" keyword argument *must* be
+        supplied at a bare minimum!
+
+    Returns:
+      |None|
+
+    Raises:
+      |KeyError| = The command specified does not exist. The **kwargs dictionary is
+        missing the required "name" key.
+    """
+
+    if command not in self._commands:
+      raise KeyError("The '{}' command has not been defined yet!".format(parent))
+    elif 'name' not in kwargs:
+      raise KeyError("The keyword argument 'name' must be specified for this method!")
+
+    arg_name = kwargs.pop('name')
+
+    self._commands[command].add_argument(arg_name, **kwargs)
 
   def add_sub_command(self, parent, sub_cmd_name, desc, func):
     """Create a sub-command for a top-level command.
@@ -101,7 +140,8 @@ class CommandParser(object):
       |None|
 
     Raises:
-      |KeyError| Command name has already been defined or parent command specified does not
+      |RuntimeError| = The parent command does not allow sub-commands.
+      |KeyError| = Command name has already been defined or parent command specified does not
         exist.
     """
 
@@ -110,6 +150,8 @@ class CommandParser(object):
 
     if parent not in self._commands:
       raise KeyError("The '{}' parent command has not been defined yet!".format(parent))
+    elif not self._commands[parent]._allow_sub_cmd:
+      raise RuntimeError("The '{}' parent command does not allow sub-commands!".format(parent))
     elif sub_cmd_key in self._sub_commands:
       raise KeyError("The '{}' sub-command has already been defined!".format(sub_cmd_key))
 
@@ -134,8 +176,8 @@ class CommandParser(object):
       |None|
 
     Raises:
-      |KeyError| The parent or sub-command specified does not exist. The **kwargs dictionary
-        is missing the required "name" key.
+      |KeyError| = The parent or sub-command specified does not exist. The **kwargs
+        dictionary is missing the required "name" key.
     """
 
     # Build unique key with composite of parent sub-command name.

--- a/vmpooler_client/command_parser.py
+++ b/vmpooler_client/command_parser.py
@@ -85,17 +85,17 @@ class CommandParser(object):
       command = self._sub_parsers.add_parser(cmd_name, description=desc)
 
       # Add a subparser for sub-commands under a top-level command. (i.e. "list" for "vm")
-      if func is None:
-        self._commands[cmd_name] = command.add_subparsers()
-
-        # Tack on this bit of meta-data to indicate that sub-commands are ALLOWED
-        self._commands[cmd_name]._allow_sub_cmd = True
-      else:
+      if func:
         self._commands[cmd_name] = command
         self._commands[cmd_name].set_defaults(func=func)
 
         # Tack on this bit of meta-data to indicate that sub-commands are NOT allowed.
         self._commands[cmd_name]._allow_sub_cmd = False
+      else:
+        self._commands[cmd_name] = command.add_subparsers()
+
+        # Tack on this bit of meta-data to indicate that sub-commands are ALLOWED
+        self._commands[cmd_name]._allow_sub_cmd = True
     else:
       raise KeyError("The '{}' command has already been defined!".format(cmd_name))
 
@@ -118,7 +118,7 @@ class CommandParser(object):
     """
 
     if command not in self._commands:
-      raise KeyError("The '{}' command has not been defined yet!".format(parent))
+      raise KeyError("The '{}' command has not been defined yet!".format(command))
     elif 'name' not in kwargs:
       raise KeyError("The keyword argument 'name' must be specified for this method!")
 

--- a/vmpooler_client/commands/config.py
+++ b/vmpooler_client/commands/config.py
@@ -1,5 +1,5 @@
 """
-.. module:: vmpooler_client.lib.commands.config
+.. module:: vmpooler_client.commands.config
    :synopsis: Sub-commands for the "config" top-level command.
    :platform: Unix, Linux, Windows
    :license: BSD

--- a/vmpooler_client/commands/lifetime.py
+++ b/vmpooler_client/commands/lifetime.py
@@ -1,5 +1,5 @@
 """
-.. module:: vmpooler_client.lib.commands.lifetime
+.. module:: vmpooler_client.commands.lifetime
    :synopsis: Sub-commands for the "lifetime" top-level command.
    :platform: Unix, Linux, Windows
    :license: BSD

--- a/vmpooler_client/commands/token.py
+++ b/vmpooler_client/commands/token.py
@@ -1,5 +1,5 @@
 """
-.. module:: vmpooler_client.lib.commands.token
+.. module:: vmpooler_client.commands.token
    :synopsis: Sub-commands for the "token" top-level command.
    :platform: Unix, Linux, Windows
    :license: BSD

--- a/vmpooler_client/commands/vm.py
+++ b/vmpooler_client/commands/vm.py
@@ -1,5 +1,5 @@
 """
-.. module:: vmpooler_client.lib.commands.vm
+.. module:: vmpooler_client.commands.vm
    :synopsis: Sub-commands for the "vm" top-level command.
    :platform: Unix, Linux, Windows
    :license: BSD

--- a/vmpooler_client/conf_file.py
+++ b/vmpooler_client/conf_file.py
@@ -1,5 +1,5 @@
 """
-.. module:: vmpooler_client.lib.config
+.. module:: vmpooler_client.config
    :synopsis: Functions for reading and writing the configuration file.
    :platform: Unix, Linux, Windows
    :license: BSD

--- a/vmpooler_client/service.py
+++ b/vmpooler_client/service.py
@@ -1,5 +1,5 @@
 """
-.. module:: vmpooler_client.lib.service
+.. module:: vmpooler_client.service
    :synopsis: Functions for communicating with the vmpooler API.
    :platform: Unix, Linux, Windows
    :license: BSD

--- a/vmpooler_client/util.py
+++ b/vmpooler_client/util.py
@@ -1,5 +1,5 @@
 """
-.. module:: vmpooler_client.lib.util
+.. module:: vmpooler_client.util
    :synopsis: Utility function used by other modules in the vmpooler_client package.
    :platform: Unix, Linux, Windows
    :license: BSD

--- a/vmpooler_client/version.py
+++ b/vmpooler_client/version.py
@@ -1,1 +1,1 @@
-version = "3.0.0"
+version = "3.1.0"

--- a/vmpooler_client_app.py
+++ b/vmpooler_client_app.py
@@ -11,10 +11,12 @@
 #===================================================================================================
 # Imports
 #===================================================================================================
+from __future__ import print_function
 import sys
 from vmpooler_client.conf_file import load_config
 from vmpooler_client.command_parser import CommandParser, valid_lifetime
 from vmpooler_client.commands import config, lifetime, token, vm
+from vmpooler_client.version import version
 
 #===================================================================================================
 # Functions: Private (Subcommands)
@@ -269,7 +271,12 @@ def configure_command_parser(argv):
   # Custom parser for CLI commands and sub-commands
   cmd_parser = CommandParser(argv)
 
-  # Top-level Commands
+  # Top-level commands WITHOUT sub-commands
+  cmd_parser.add_command('version',
+                         desc='Print the vmpooler_client_app version',
+                         func=lambda *args, **kwargs: print(version))
+
+  # Top-level commands with sub-commands
   cmd_parser.add_command('config', desc='Read and modify the vmpooler configuration file')
   cmd_parser.add_command('lifetime', desc='Manage the lifetime of VM instances')
   cmd_parser.add_command('token', desc='Manage auth tokens')


### PR DESCRIPTION
Add a command for printing the version of the vmpooler-client. This
required changing how commands are generated in the CommandParser.
Also, I corrected some small doc string issues.