### PR TITLE
Rename vmpooler_url to vmpooler_hostname

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ To get help on the command-line for the script use the command:
 
 ::
 
-    vmpooler_client.py -h
+    vmpooler_client_app.py -h
 
 Quickstart
 ~~~~~~~~~~
@@ -19,7 +19,7 @@ Quickstart
 ::
 
     # Create a token (only on first run)
-    $ ./vmpooler_client.py token create
+    $ ./vmpooler_client_app.py token create
     Please provide LDAP credentials for the VM pooler
 
     Username: bob.smith
@@ -28,7 +28,7 @@ Quickstart
     Token: <token>
 
     # List available templates
-    $ ./vmpooler_client.py vm list redhat
+    $ ./vmpooler_client_app.py vm list redhat
     redhat-4-x86_64
     redhat-5-i386
     redhat-5-x86_64
@@ -37,7 +37,7 @@ Quickstart
     redhat-7-x86_64
 
     # Grab a VM
-    $ ./vmpooler_client.py vm get redhat-6-x86_64
+    $ ./vmpooler_client_app.py vm get redhat-6-x86_64
     Hostname: h2qbe7c29ix2w1r
 
     # Login and do work
@@ -46,16 +46,16 @@ Quickstart
     # Logout
 
     # Give vm back to the pool
-    $ ./vmpooler_client.py vm destroy h2qbe7c29ix2w1r
+    $ ./vmpooler_client_app.py vm destroy h2qbe7c29ix2w1r
 
 Examples
 ~~~~~~~~
 
-``vmpooler_client.py`` is separated into a few subcommands:
+``vmpooler_client_app.py`` is separated into a few subcommands:
 
 ::
 
-    vmpooler_client.py
+    vmpooler_client_app.py
         * vm
             * list
             * get
@@ -82,7 +82,7 @@ command:
 
 ::
 
-    vmpooler_client.py lifetime set -h
+    vmpooler_client_app.py lifetime set -h
 
 List vmpooler templates
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -93,7 +93,7 @@ This will list all the available templates.
 
 ::
 
-    vmpooler_client.py vm list
+    vmpooler_client_app.py vm list
 
 Filter the list vmpooler templates
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -104,13 +104,13 @@ Filter available templates via a fuzzy matching pattern.
 
 ::
 
-    vmpooler_client.py vm list PATTERN
+    vmpooler_client_app.py vm list PATTERN
 
 **Example**
 
 ::
 
-    vmpooler_client.py vm list win
+    vmpooler_client_app.py vm list win
 
 Get a VM from the vmpooler
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -122,13 +122,13 @@ Get a VM from the vmpooler
 
 ::
 
-    vmpooler_client.py vm get TEMPLATE_NAME
+    vmpooler_client_app.py vm get TEMPLATE_NAME
 
 **Example**
 
 ::
 
-    vmpooler_client.py vm get ubuntu-1404-x86_64
+    vmpooler_client_app.py vm get ubuntu-1404-x86_64
 
 List all of your running VMs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -139,7 +139,7 @@ This gives you a concise list of what VMs you have running
 
 ::
 
-    vmpooler_client.py vm running
+    vmpooler_client_app.py vm running
 
 **Example Output**
 
@@ -159,13 +159,13 @@ Hand a VM back to the vmpooler for destruction
 
 ::
 
-    vmpooler_client.py vm destroy VM_NAME
+    vmpooler_client_app.py vm destroy VM_NAME
 
 **Example**
 
 ::
 
-    vmpooler_client.py vm destroy skj3k4hahdk
+    vmpooler_client_app.py vm destroy skj3k4hahdk
 
 Hand all active VMs back to the vmpooler for destruction
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -176,7 +176,7 @@ Be careful, this will destroy every active VM associate with your token
 
 ::
 
-    vmpooler_client.py vm destroy_all
+    vmpooler_client_app.py vm destroy_all
 
 **Example Output**
 
@@ -192,13 +192,13 @@ Get the time to live for a VM in the vmpooler
 
 ::
 
-    vmpooler_client.py lifetime get VM_NAME
+    vmpooler_client_app.py lifetime get VM_NAME
 
 **Example**
 
 ::
 
-    vmpooler_client.py lifetime get skj3k4hahdk
+    vmpooler_client_app.py lifetime get skj3k4hahdk
 
 Extend the time to live for a VM in the vmpooler
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -208,13 +208,13 @@ This command will add a certain number of hours to the lifetime of a VM
 
 ::
 
-    vmpooler_client.py lifetime extend VM_NAME LIFETIME
+    vmpooler_client_app.py lifetime extend VM_NAME LIFETIME
 
 **Example**
 
 ::
 
-    vmpooler_client.py lifetime extend skj3k4hahdk 2
+    vmpooler_client_app.py lifetime extend skj3k4hahdk 2
     > Lifetime extended to 10 hours
 
 Set the total time to live for a VM in the vmpooler to a certain number of hours
@@ -226,13 +226,13 @@ This command will overwrite the time to live for a VM
 
 ::
 
-    vmpooler_client.py lifetime set VM_NAME LIFETIME
+    vmpooler_client_app.py lifetime set VM_NAME LIFETIME
 
 **Example**
 
 ::
 
-    vmpooler_client.py lifetime set skj3k4hahdk 24
+    vmpooler_client_app.py lifetime set skj3k4hahdk 24
 
 Get information on a VM in the vmpooler
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -243,13 +243,13 @@ This will work on running and destroyed VMs in the vmpooler.
 
 ::
 
-    vmpooler_client.py vm info VM_NAME
+    vmpooler_client_app.py vm info VM_NAME
 
 **Example**
 
 ::
 
-    vmpooler_client.py vm info skj3k4hahdk
+    vmpooler_client_app.py vm info skj3k4hahdk
 
 Create an authorization token for use with the vmpooler
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -260,7 +260,7 @@ WARNING! Know what you’re doing before using this function!
 
 ::
 
-    vmpooler_client.py token create
+    vmpooler_client_app.py token create
 
 Revoke an authorization token
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -271,13 +271,13 @@ WARNING! Know what you’re doing before using this function!
 
 ::
 
-    vmpooler_client.py token revoke TOKEN
+    vmpooler_client_app.py token revoke TOKEN
 
 **Example**
 
 ::
 
-    vmpooler_client.py token revoke sfn3h65earxah6ar9aal3oac2pfx9817
+    vmpooler_client_app.py token revoke sfn3h65earxah6ar9aal3oac2pfx9817
 
 Verify that an authorization token is valid
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -288,13 +288,13 @@ WARNING! Know what you’re doing before using this function!
 
 ::
 
-    vmpooler_client.py token validate TOKEN
+    vmpooler_client_app.py token validate TOKEN
 
 **Example**
 
 ::
 
-    vmpooler_client.py token validate sfn3h65earxah6ar9aal3oac2pfx9817
+    vmpooler_client_app.py token validate sfn3h65earxah6ar9aal3oac2pfx9817
 
 Read a config setting
 ^^^^^^^^^^^^^^^^^^^^^
@@ -303,13 +303,13 @@ Read a config setting
 
 ::
 
-    vmpooler_client.py config get SETTING_NAME
+    vmpooler_client_app.py config get SETTING_NAME
 
 **Example**
 
 ::
 
-    vmpooler_client.py config get username
+    vmpooler_client_app.py config get username
 
 Modify/create a config setting
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -321,14 +321,14 @@ exist yet.
 
 ::
 
-    vmpooler_client.py config set SETTING_NAME VALUE
+    vmpooler_client_app.py config set SETTING_NAME VALUE
 
 **Examples**
 
 ::
 
-    vmpooler_client.py config set username bob.smith
-    vmpooler_client.py config set a_new_setting some_value
+    vmpooler_client_app.py config set username bob.smith
+    vmpooler_client_app.py config set a_new_setting some_value
 
 Remove a config setting
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -337,13 +337,13 @@ Remove a config setting
 
 ::
 
-    vmpooler_client.py config unset SETTING_NAME
+    vmpooler_client_app.py config unset SETTING_NAME
 
 **Example**
 
 ::
 
-    vmpooler_client.py config unset auth_token
+    vmpooler_client_app.py config unset auth_token
 
 List all config settings
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -353,4 +353,4 @@ List all config settings
 
 ::
 
-    vmpooler_client.py config list
+    vmpooler_client_app.py config list

--- a/tests/unit/service_tests.py
+++ b/tests/unit/service_tests.py
@@ -38,7 +38,7 @@ class ServiceTests(TestCase):
   """Tests for the ResourceConfig class in the config module."""
 
   def setUp(self):
-    self.vmpooler_url = 'vmpooler.delivery.puppetlabs.net'
+    self.vmpooler_hostname = 'vmpooler.delivery.puppetlabs.net'
     self.template_name = 'centos-4-x86_64'
     self.hostname = 'j2bgvv6x1ihqslx'
     self.auth_token = 'bdct6vxix5yfxndry32kmark0pyhriq9'
@@ -62,7 +62,7 @@ class ServiceTests(TestCase):
 
     # Patch
     with patch.object(service, '_make_request', return_value=resp) as mock_func:
-      self.assertEqual(service.get_vm(self.vmpooler_url,
+      self.assertEqual(service.get_vm(self.vmpooler_hostname,
                                       self.template_name,
                                       self.auth_token),
                        self.hostname)
@@ -79,7 +79,7 @@ class ServiceTests(TestCase):
     # Patch
     with patch.object(service, '_make_request', return_value=resp) as mock_func:
       with self.assertRaises(RuntimeError) as cm:
-        service.get_vm(self.vmpooler_url, self.template_name, self.auth_token)
+        service.get_vm(self.vmpooler_hostname, self.template_name, self.auth_token)
 
         excep = cm.exception
 
@@ -100,7 +100,7 @@ class ServiceTests(TestCase):
 
     # Patch
     with patch.object(service, '_make_request', return_value=resp) as mock_func:
-      self.assertListEqual(service.list_vm(self.vmpooler_url,
+      self.assertListEqual(service.list_vm(self.vmpooler_hostname,
                                            self.auth_token),
                            expected_machines)
 
@@ -132,7 +132,7 @@ class ServiceTests(TestCase):
 
     # Patch
     with patch.object(service, '_make_request', return_value=resp) as mock_func:
-      self.assertDictEqual(service.info_vm(self.vmpooler_url,
+      self.assertDictEqual(service.info_vm(self.vmpooler_hostname,
                                            self.hostname,
                                            self.auth_token),
                            expected_info)
@@ -148,7 +148,7 @@ class ServiceTests(TestCase):
 
     # Patch
     with patch.object(service, '_make_request', return_value=resp) as mock_func:
-      service.destroy_vm(self.vmpooler_url, self.hostname, self.auth_token)
+      service.destroy_vm(self.vmpooler_hostname, self.hostname, self.auth_token)
 
   @skipIf(SKIP_EVERYTHING, 'Skip if we are creating/modifying tests!')
   def test06_destroy_vm_neg(self):
@@ -162,7 +162,7 @@ class ServiceTests(TestCase):
     # Patch
     with patch.object(service, '_make_request', return_value=resp) as mock_func:
       with self.assertRaises(RuntimeError) as cm:
-        service.destroy_vm(self.vmpooler_url, self.hostname, self.auth_token)
+        service.destroy_vm(self.vmpooler_hostname, self.hostname, self.auth_token)
 
         excep = cm.exception
 
@@ -182,7 +182,7 @@ class ServiceTests(TestCase):
 
     # Patch
     with patch.object(service, '_make_request', return_value=resp) as mock_func:
-      service.set_vm_lifetime(self.vmpooler_url, self.hostname, lifetime, self.auth_token)
+      service.set_vm_lifetime(self.vmpooler_hostname, self.hostname, lifetime, self.auth_token)
 
   @skipIf(SKIP_EVERYTHING, 'Skip if we are creating/modifying tests!')
   def test08_set_vm_lifetime_neg(self):
@@ -199,7 +199,7 @@ class ServiceTests(TestCase):
     # Patch
     with patch.object(service, '_make_request', return_value=resp) as mock_func:
       with self.assertRaises(RuntimeError) as cm:
-        service.set_vm_lifetime(self.vmpooler_url, self.hostname, lifetime, self.auth_token)
+        service.set_vm_lifetime(self.vmpooler_hostname, self.hostname, lifetime, self.auth_token)
 
         excep = cm.exception
 

--- a/vmpooler_client/commands/lifetime.py
+++ b/vmpooler_client/commands/lifetime.py
@@ -10,7 +10,7 @@
 #===================================================================================================
 # Imports
 #===================================================================================================
-from ..conf_file import get_vmpooler_url, get_auth_token
+from ..conf_file import get_vmpooler_hostname, get_auth_token
 from ..service import info_vm, set_vm_lifetime
 from ..util import MAX_LIFETIME
 
@@ -31,7 +31,7 @@ def get(args, config):
     |None|
   """
 
-  lifetime = info_vm(get_vmpooler_url(config), args.hostname, get_auth_token(config))["lifetime"]
+  lifetime = info_vm(get_vmpooler_hostname(config), args.hostname, get_auth_token(config))["lifetime"]
 
   print("lifetime: {} hours".format(lifetime))
 
@@ -50,7 +50,7 @@ def set(args, config):
     |None|
   """
 
-  set_vm_lifetime(get_vmpooler_url(config), args.hostname, args.hours, get_auth_token(config))
+  set_vm_lifetime(get_vmpooler_hostname(config), args.hostname, args.hours, get_auth_token(config))
 
 
 def extend(args, config):
@@ -67,7 +67,7 @@ def extend(args, config):
     |RuntimeError| = If the new lifetime would exceed the maximum allowed lifetime
   """
 
-  vm_info = info_vm(get_vmpooler_url(config), args.hostname, get_auth_token(config))
+  vm_info = info_vm(get_vmpooler_hostname(config), args.hostname, get_auth_token(config))
   running = round(float(vm_info["running"]))
   extension = int(args.hours)
 
@@ -78,6 +78,6 @@ def extend(args, config):
              'hours'.format(new_lifetime, MAX_LIFETIME))
     raise RuntimeError(error)
 
-  set_vm_lifetime(get_vmpooler_url(config), args.hostname, new_lifetime, get_auth_token(config))
+  set_vm_lifetime(get_vmpooler_hostname(config), args.hostname, new_lifetime, get_auth_token(config))
 
   print("Lifetime extended to roughly {} hours from now".format(extension))

--- a/vmpooler_client/commands/token.py
+++ b/vmpooler_client/commands/token.py
@@ -10,7 +10,7 @@
 #===================================================================================================
 # Imports
 #===================================================================================================
-from ..conf_file import write_config, get_credentials, get_vmpooler_url
+from ..conf_file import write_config, get_credentials, get_vmpooler_hostname
 from ..service import create_auth_token, get_token_info, revoke_auth_token
 from ..util import pretty_print
 
@@ -32,7 +32,7 @@ def create(args, config):
   """
   (username, password) = get_credentials(config)
 
-  config['auth_token'] = create_auth_token(get_vmpooler_url(config), username, password)
+  config['auth_token'] = create_auth_token(get_vmpooler_hostname(config), username, password)
 
   write_config(config)
   print('\nToken: {0}'.format(config['auth_token']))
@@ -52,7 +52,7 @@ def validate(args, config):
     |None|
   """
 
-  pretty_print(get_token_info(get_vmpooler_url(config), args.token))
+  pretty_print(get_token_info(get_vmpooler_hostname(config), args.token))
 
 
 def revoke(args, config):
@@ -71,7 +71,7 @@ def revoke(args, config):
 
   (username, password) = get_credentials(config)
   print('')
-  revoke_auth_token(get_vmpooler_url(config), username, password, args.token)
+  revoke_auth_token(get_vmpooler_hostname(config), username, password, args.token)
 
   config['auth_token'] = ''
 

--- a/vmpooler_client/commands/vm.py
+++ b/vmpooler_client/commands/vm.py
@@ -10,7 +10,7 @@
 #===================================================================================================
 # Imports
 #===================================================================================================
-from ..conf_file import get_vmpooler_url, get_auth_token
+from ..conf_file import get_vmpooler_hostname, get_auth_token
 from ..service import get_vm, list_vm, info_vm, destroy_vm, get_token_info
 from ..util import pretty_print
 
@@ -65,11 +65,11 @@ def _fuzzy_filter(match, string_list):
   return [vm for vm in string_list if _fuzzy_match(match, vm)]
 
 
-def _list_running_vms(vmpooler_url, auth_token):
+def _list_running_vms(vmpooler_hostname, auth_token):
   """Returns a list of the running vms for a given auth token.
 
   Args:
-    vmpooler_url |str| = The URL of the vmpooler
+    vmpooler_hostname |str| = The URL of the vmpooler
     auth_token |str| = The authentication token for the user
 
   Returns:
@@ -79,7 +79,7 @@ def _list_running_vms(vmpooler_url, auth_token):
     |None|
   """
 
-  token_info = get_token_info(vmpooler_url, auth_token)
+  token_info = get_token_info(vmpooler_hostname, auth_token)
 
   if "vms" in token_info:
     return token_info["vms"]["running"]
@@ -105,7 +105,7 @@ def list(args, config):
   """
 
   search_string = args.platform
-  templates = list_vm(get_vmpooler_url(config), get_auth_token(config))
+  templates = list_vm(get_vmpooler_hostname(config), get_auth_token(config))
 
   if search_string:
     templates = (template for template in _fuzzy_filter(search_string, templates))
@@ -130,7 +130,7 @@ def get(args, config):
     |None|
   """
 
-  hostname = get_vm(get_vmpooler_url(config), args.platform, get_auth_token(config))
+  hostname = get_vm(get_vmpooler_hostname(config), args.platform, get_auth_token(config))
   print('Hostname: {0}'.format(hostname))
 
 
@@ -148,7 +148,7 @@ def info(args, config):
     |None|
   """
 
-  pretty_print(info_vm(get_vmpooler_url(config), args.hostname, get_auth_token(config)))
+  pretty_print(info_vm(get_vmpooler_hostname(config), args.hostname, get_auth_token(config)))
 
 
 def destroy(args, config):
@@ -165,7 +165,7 @@ def destroy(args, config):
     |None|
   """
 
-  destroy_vm(get_vmpooler_url(config), args.hostname, get_auth_token(config))
+  destroy_vm(get_vmpooler_hostname(config), args.hostname, get_auth_token(config))
 
 
 def destroy_all(args, config):
@@ -183,13 +183,13 @@ def destroy_all(args, config):
     |None|
   """
 
-  vmpooler_url = get_vmpooler_url(config)
+  vmpooler_hostname = get_vmpooler_hostname(config)
   auth_token = get_auth_token(config)
-  vm_list = _list_running_vms(vmpooler_url, auth_token)
+  vm_list = _list_running_vms(vmpooler_hostname, auth_token)
 
   for vm in vm_list:
     print("Destroying {}".format(vm))
-    destroy_vm(vmpooler_url, vm, auth_token)
+    destroy_vm(vmpooler_hostname, vm, auth_token)
 
   if not vm_list:
     print("No VMs to destroy")
@@ -209,12 +209,12 @@ def running(args, config):
     |None|
   """
 
-  vmpooler_url = get_vmpooler_url(config)
+  vmpooler_hostname = get_vmpooler_hostname(config)
   auth_token = get_auth_token(config)
-  vm_list = _list_running_vms(vmpooler_url, auth_token)
+  vm_list = _list_running_vms(vmpooler_hostname, auth_token)
 
   # Associate the hostname with its info
-  vm_info_dict = dict((vm, info_vm(vmpooler_url, vm, auth_token)) for vm in vm_list)
+  vm_info_dict = dict((vm, info_vm(vmpooler_hostname, vm, auth_token)) for vm in vm_list)
 
   # Sort on how long they've been running
   sorted_vm_info = sorted(vm_info_dict.items(),

--- a/vmpooler_client/conf_file.py
+++ b/vmpooler_client/conf_file.py
@@ -185,19 +185,19 @@ def get_credentials(config):
   return (config["username"], getpass('Password: '))
 
 
-def get_vmpooler_url(config):
-  """Request the vmpooler URL from the user.
-    If a URL is found in the config, defaults to that URL,
-    otherwise requests a URL and updates the config
+def get_vmpooler_hostname(config):
+  """Request the vmpooler hostname from the user.
+    If a hostname is found in the config, defaults to that hostname,
+    otherwise requests a hostname and updates the config
 
   Args:
     config |{str:str}| = A dictionary of configuration values.
 
   Returns:
-    vmpooler_url |str| = The vmpooler url
+    vmpooler_hostname |str| = The vmpooler hostname
 
   Raises:
     |None|
   """
-  prompt = "Please enter the URL of the vmpooler. This will only be requested once"
-  return request_config_value(config, "vmpooler_url", prompt)
+  prompt = "Please enter the hostname of the vmpooler. This will only be requested once"
+  return request_config_value(config, "vmpooler_hostname", prompt)

--- a/vmpooler_client/service.py
+++ b/vmpooler_client/service.py
@@ -92,12 +92,12 @@ def _create_auth_token_header(auth_token):
 #===================================================================================================
 # Functions: Public
 #===================================================================================================
-def create_auth_token(vmpooler_url, username, password):
+def create_auth_token(vmpooler_hostname, username, password):
   """
   Generate an authorization token.
 
   Args:
-    vmpooler_url |str| = The URL of the vmpooler
+    vmpooler_hostname |str| = The URL of the vmpooler
     username |str| = The username for the authorization token request.
     password |str| = The password for the authorization token request.
 
@@ -109,7 +109,7 @@ def create_auth_token(vmpooler_url, username, password):
   """
 
   resp = _make_request('POST',
-                       vmpooler_url,
+                       vmpooler_hostname,
                        '/token',
                        headers=_create_basic_auth_header(username, password))
 
@@ -124,12 +124,12 @@ def create_auth_token(vmpooler_url, username, password):
   return loads(resp.read())['token']
 
 
-def get_token_info(vmpooler_url, auth_token, suppress_return=False):
+def get_token_info(vmpooler_hostname, auth_token, suppress_return=False):
   """
   Verify that an authorization token is still valid.
 
   Args:
-    vmpooler_url |str| = The URL of the vmpooler
+    vmpooler_hostname |str| = The URL of the vmpooler
     auth_token |str| = The authorization token to validate.
     suppress_return |bln| = Suppress returning token information.
 
@@ -140,7 +140,7 @@ def get_token_info(vmpooler_url, auth_token, suppress_return=False):
     |RuntimeError| = The request was bad or incorrect credentials provided.
   """
 
-  resp = _make_request('GET', vmpooler_url, '/token/{0}'.format(auth_token))
+  resp = _make_request('GET', vmpooler_hostname, '/token/{0}'.format(auth_token))
 
   if resp.status == 404:
     raise RuntimeError('Token already revoked or invalid token specified!')
@@ -153,12 +153,12 @@ def get_token_info(vmpooler_url, auth_token, suppress_return=False):
     return loads(resp.read())[auth_token]
 
 
-def revoke_auth_token(vmpooler_url, username, password, auth_token):
+def revoke_auth_token(vmpooler_hostname, username, password, auth_token):
   """
   Revoke an authorization token.
 
   Args:
-    vmpooler_url |str| = The URL of the vmpooler
+    vmpooler_hostname |str| = The URL of the vmpooler
     username |str| = The username for the authorization token request.
     password |str| = The password for the authorization token request.
     auth_token |str| = The authorization token to revoke.
@@ -171,7 +171,7 @@ def revoke_auth_token(vmpooler_url, username, password, auth_token):
   """
 
   resp = _make_request('DELETE',
-                       vmpooler_url,
+                       vmpooler_hostname,
                        '/token/{0}'.format(auth_token),
                        headers=_create_basic_auth_header(username, password))
 
@@ -180,11 +180,11 @@ def revoke_auth_token(vmpooler_url, username, password, auth_token):
     raise RuntimeError(errmsg)
 
 
-def list_vm(vmpooler_url, auth_token):
+def list_vm(vmpooler_hostname, auth_token):
   """Retrieve a list of availabe VM templates from the pooler.
 
   Args:
-    vmpooler_url |str| = The URL of the vmpooler
+    vmpooler_hostname |str| = The URL of the vmpooler
     auth_token |str| = The authentication token for the user
 
   Returns:
@@ -196,7 +196,7 @@ def list_vm(vmpooler_url, auth_token):
   """
 
   resp = _make_request('GET',
-                       vmpooler_url,
+                       vmpooler_hostname,
                        '/vm',
                        headers=_create_auth_token_header(auth_token))
 
@@ -213,11 +213,11 @@ def list_vm(vmpooler_url, auth_token):
   return vmpooler_status
 
 
-def get_vm(vmpooler_url, template_name, auth_token):
+def get_vm(vmpooler_hostname, template_name, auth_token):
   """Retrieve a VM from the vmpooler and return the hostname.
 
   Args:
-    vmpooler_url |str| = The URL of the vmpooler
+    vmpooler_hostname |str| = The URL of the vmpooler
     template_name |str| = The name of the template on the vmpooler.
     auth_token |str| = The authentication token for the user
 
@@ -229,7 +229,7 @@ def get_vm(vmpooler_url, template_name, auth_token):
   """
 
   resp = _make_request('POST',
-                       vmpooler_url,
+                       vmpooler_hostname,
                        '/vm/{0}'.format(template_name),
                        headers=_create_auth_token_header(auth_token))
 
@@ -248,11 +248,11 @@ def get_vm(vmpooler_url, template_name, auth_token):
   return vmpooler_status[template_name]['hostname']
 
 
-def info_vm(vmpooler_url, vm_name, auth_token):
+def info_vm(vmpooler_hostname, vm_name, auth_token):
   """Retrieve information for a VM in the vmpooler.
 
   Args:
-    vmpooler_url |str| = The URL of the vmpooler
+    vmpooler_hostname |str| = The URL of the vmpooler
     vm_name |str| = The name of the VM from which to retrieve information.
     auth_token |str| = The authentication token for the user
 
@@ -264,7 +264,7 @@ def info_vm(vmpooler_url, vm_name, auth_token):
   """
 
   resp = _make_request('GET',
-                       vmpooler_url,
+                       vmpooler_hostname,
                        '/vm/{0}'.format(vm_name),
                        headers=_create_auth_token_header(auth_token))
 
@@ -278,11 +278,11 @@ def info_vm(vmpooler_url, vm_name, auth_token):
   return loads(resp.read())[vm_name]
 
 
-def destroy_vm(vmpooler_url, vm_name, auth_token):
+def destroy_vm(vmpooler_hostname, vm_name, auth_token):
   """Hand a VM back to the vmpooler to be destroyed.
 
   Args:
-    vmpooler_url |str| = The URL of the vmpooler
+    vmpooler_hostname |str| = The URL of the vmpooler
     vm_name |str| = The name of the VM (hostname) to destroy.
     auth_token |str| = The authentication token for the user
 
@@ -294,7 +294,7 @@ def destroy_vm(vmpooler_url, vm_name, auth_token):
   """
 
   resp = _make_request('DELETE',
-                       vmpooler_url,
+                       vmpooler_hostname,
                        '/vm/{0}'.format(vm_name),
                        headers=_create_auth_token_header(auth_token))
 
@@ -306,11 +306,11 @@ def destroy_vm(vmpooler_url, vm_name, auth_token):
     raise RuntimeError(errmsg)
 
 
-def set_vm_lifetime(vmpooler_url, vm_name, lifetime, auth_token):
+def set_vm_lifetime(vmpooler_hostname, vm_name, lifetime, auth_token):
   """Set the time to live for a VM.
 
   Args:
-    vmpooler_url |str| = The URL of the vmpooler
+    vmpooler_hostname |str| = The URL of the vmpooler
     vm_name |str| = The name of the VM (hostname) to set time to live.
     lifetime |int| = The number of hours to set the time to live for the VM.
     auth_token |str| = The authentication token for the user
@@ -323,7 +323,7 @@ def set_vm_lifetime(vmpooler_url, vm_name, lifetime, auth_token):
   """
 
   resp = _make_request('PUT',
-                       vmpooler_url,
+                       vmpooler_hostname,
                        '/vm/{}'.format(vm_name),
                        body='{{"lifetime":"{}"}}'.format(lifetime),
                        headers=_create_auth_token_header(auth_token))


### PR DESCRIPTION
When I first used this project to create a token, the script asked me for the URL for the vmpooler. I tried with http:// and https:// and then realised that the errors I was getting is because it actually just wants a hostname. 

Example error that I was seeing:

```
$ ./vmpooler_client_app.py token create
Please provide LDAP credentials for the VM pooler

Username: jesse.reynolds
Password:
Please enter the URL of the vmpooler. This will only be requested once: http://vmpooler.delivery.puppetlabs.net
Unkown error occured while trying to connect to http://vmpooler.delivery.puppetlabs.net
Traceback (most recent call last):
  File "./vmpooler_client_app.py", line 329, in <module>
    sys.exit(main(sys.argv))
  File "./vmpooler_client_app.py", line 317, in main
    cmd_parser.parse_execute(config=config)
  File "/Users/jesse/src/puppetlabs/vmpooler-client/vmpooler_client/command_parser.py", line 172, in parse_execute
    args.func(args, **kwargs)
  File "/Users/jesse/src/puppetlabs/vmpooler-client/vmpooler_client/commands/token.py", line 35, in create
    config['auth_token'] = create_auth_token(get_vmpooler_url(config), username, password)
  File "/Users/jesse/src/puppetlabs/vmpooler-client/vmpooler_client/service.py", line 114, in create_auth_token
    headers=_create_basic_auth_header(username, password))
  File "/Users/jesse/src/puppetlabs/vmpooler-client/vmpooler_client/service.py", line 40, in _make_request
    conn = HTTPConnection(host)
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/httplib.py", line 712, in __init__
    (self.host, self.port) = self._get_hostport(host, port)
  File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/httplib.py", line 754, in _get_hostport
    raise InvalidURL("nonnumeric port: '%s'" % host[i+1:])
httplib.InvalidURL: nonnumeric port: '//vmpooler.delivery.puppetlabs.net'
```

I also fixed the name of the top level script in the examples in the readme because it looks like it was renamed from vmpooler_client.py to vmpooler_client_app.py at some point. 
